### PR TITLE
remove the innocent

### DIFF
--- a/skids.json
+++ b/skids.json
@@ -182,13 +182,6 @@
     "created_at": "2020-11-02T10:45:15.567Z"
   },
   {
-    "uid": "555536439870357527",
-    "tag": "Demetrius Demarcus Bartholomew#0001",
-    "avatar": "c8952c295b42928d56cecff9db5ad6bc",
-    "bot": false,
-    "created_at": "2019-03-13T23:43:28.633Z"
-  },
-  {
     "uid": "312317505135706115",
     "tag": "XEXIF#8631",
     "avatar": "7efe1638f76e34f0c528427a67b1e59f",


### PR DESCRIPTION
this person was put on the list because back when era was skidding, they had a joke role named "owoner" and it was automatically assumed that they were part of era and was a skid.